### PR TITLE
chore: disable drag node

### DIFF
--- a/@types/DiagramSchema.ts
+++ b/@types/DiagramSchema.ts
@@ -13,6 +13,7 @@ export type NodeCoordinates = [number, number];
 export type Node<P> = {
   id: string;
   coordinates: NodeCoordinates;
+  disableDrag?: boolean;
   content?: ReactNode;
   inputs?: Port[];
   outputs?: Port[];

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -11,6 +11,7 @@ const initialSchema = {
         { id: 'port-1', alignment: 'right' },
         { id: 'port-2', alignment: 'right' },
       ],
+      disableDrag: true,
       data: {
         foo: 'bar',
         count: 0,

--- a/src/Diagram/Diagram.js
+++ b/src/Diagram/Diagram.js
@@ -21,7 +21,9 @@ const Diagram = (props) => {
 
   // when nodes change, performs the onChange callback with the new incoming data
   const onNodesChange = (nextNodes) => {
-    onChange({ nodes: nextNodes });
+    if (onChange) {
+      onChange({ nodes: nextNodes });
+    }
   };
 
   // when a port is registered, save it to the local reference
@@ -55,13 +57,17 @@ const Diagram = (props) => {
   // with the new data, then reset the segment state
   const onSegmentConnect = (input, output) => {
     const nextLinks = [...(schema.links || []), { input, output }];
-    onChange({ links: nextLinks });
+    if (onChange) {
+      onChange({ links: nextLinks });
+    }
     setSegment(undefined);
   };
 
   // when links change, performs the onChange callback with the new incoming data
   const onLinkDelete = (nextLinks) => {
-    onChange({ links: nextLinks });
+    if (onChange) {
+      onChange({ links: nextLinks });
+    }
   };
 
   return (

--- a/src/Diagram/DiagramNode/DiagramNode.js
+++ b/src/Diagram/DiagramNode/DiagramNode.js
@@ -16,26 +16,31 @@ import useNodeUnregistration from '../../shared/internal_hooks/useNodeUnregistra
 const DiagramNode = (props) => {
   const {
     id, content, coordinates, type, inputs, outputs, data, onPositionChange, onPortRegister, onNodeRemove,
-    onDragNewSegment, onMount, onSegmentFail, onSegmentConnect, render, className,
+    onDragNewSegment, onMount, onSegmentFail, onSegmentConnect, render, className, disableDrag,
   } = props;
   const registerPort = usePortRegistration(inputs, outputs, onPortRegister); // get the port registration method
   const { ref, onDragStart, onDrag } = useDrag({ throttleBy: 14 }); // get the drag n drop methods
   const dragStartPoint = useRef(coordinates); // keeps the drag start point in a persistent reference
 
-  // when drag starts, save the starting coordinates into the `dragStartPoint` ref
-  onDragStart(() => {
-    dragStartPoint.current = coordinates;
-  });
+  if (!disableDrag) {
+    // when drag starts, save the starting coordinates into the `dragStartPoint` ref
+    onDragStart(() => {
+      dragStartPoint.current = coordinates;
+    });
 
-  // whilst dragging calculates the next coordinates and perform the `onPositionChange` callback
-  onDrag((event, info) => {
-    if (onPositionChange) {
-      event.stopImmediatePropagation();
-      event.stopPropagation();
-      const nextCoords = [dragStartPoint.current[0] - info.offset[0], dragStartPoint.current[1] - info.offset[1]];
-      onPositionChange(id, nextCoords);
-    }
-  });
+    // whilst dragging calculates the next coordinates and perform the `onPositionChange` callback
+    onDrag((event, info) => {
+      if (onPositionChange) {
+        event.stopImmediatePropagation();
+        event.stopPropagation();
+        const nextCoords = [
+          dragStartPoint.current[0] - info.offset[0],
+          dragStartPoint.current[1] - info.offset[1],
+        ];
+        onPositionChange(id, nextCoords);
+      }
+    });
+  }
 
   // on component unmount, remove its references
   useNodeUnregistration(onNodeRemove, inputs, outputs, id);
@@ -138,6 +143,7 @@ DiagramNode.propTypes = {
    * The possible className
    */
   className: PropTypes.string,
+  disableDrag: PropTypes.bool,
 };
 
 DiagramNode.defaultProps = {
@@ -155,6 +161,7 @@ DiagramNode.defaultProps = {
   onSegmentFail: undefined,
   onSegmentConnect: undefined,
   className: '',
+  disableDrag: false,
 };
 
 export default React.memo(DiagramNode);

--- a/src/Diagram/DiagramNode/DiagramNode.js
+++ b/src/Diagram/DiagramNode/DiagramNode.js
@@ -59,7 +59,7 @@ const DiagramNode = (props) => {
   const customRenderProps = { id, render, content, type, inputs: InputPorts, outputs: OutputPorts, data, className };
 
   return (
-    <div className={classList} ref={ref} style={getDiagramNodeStyle(coordinates)}>
+    <div className={classList} ref={ref} style={getDiagramNodeStyle(coordinates, disableDrag)}>
       {render && typeof render === 'function' && render(customRenderProps)}
       {!render && (
         <>

--- a/src/Diagram/DiagramNode/getDiagramNodeStyle.js
+++ b/src/Diagram/DiagramNode/getDiagramNodeStyle.js
@@ -1,6 +1,7 @@
-const getDiagramNodeStyle = (coordinates) => ({
+const getDiagramNodeStyle = (coordinates, disableDrag) => ({
   left: coordinates[0],
   top: coordinates[1],
+  cursor: disableDrag ? undefined : 'move',
 });
 
 export default getDiagramNodeStyle;

--- a/src/Diagram/NodesCanvas/updateNodeCoordinates.js
+++ b/src/Diagram/NodesCanvas/updateNodeCoordinates.js
@@ -7,7 +7,7 @@ import findIndex from 'lodash.findindex';
 const updateNodeCoordinates = (nodeId, coordinates, nodes) => {
   const index = findIndex(nodes, ['id', nodeId]);
 
-  if (index > -1) {
+  if (index > -1 && !nodes[index].disableDrag) {
     // eslint-disable-next-line no-param-reassign
     nodes[index].coordinates = coordinates;
   }

--- a/src/Diagram/diagram.scss
+++ b/src/Diagram/diagram.scss
@@ -17,7 +17,6 @@
     box-sizing: content-box;
     position: absolute;
     z-index: 50;
-    cursor: move;
     user-select: none;
 
     .bi-port-wrapper {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

added `disableDrag` options

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/projectstorm/react-diagrams/blob/master/packages/diagrams-demo-gallery/demos/demo-canvas-drag/index.tsx

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Because I want to lay out with the library currently under development
- https://github.com/caddijp/beautiful-react-diagrams-routing

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![Kapture 2020-11-13 at 15 24 31](https://user-images.githubusercontent.com/520693/99036212-99422a00-25c4-11eb-9103-1433c3cf75f0.gif)

