### PR TITLE
fix(@types): improve types of DiagramNode

### DIFF
--- a/@types/DiagramSchema.ts
+++ b/@types/DiagramSchema.ts
@@ -1,4 +1,4 @@
-import { ElementType, ReactElement, ReactNode } from 'react';
+import { ElementType, HTMLAttributes, ReactElement, ReactNode } from 'react';
 
 export type PortAlignment = 'right' | 'left' | 'top' | 'bottom';
 
@@ -26,7 +26,10 @@ export type Node<P> = {
 export type NodeRenderProps<P> = Omit<
   Node<P>,
   'coordinates' | 'disableDrag' | 'inputs' | 'outputs'
-> & { inputs: ReactElement<Port>[]; outputs: ReactElement<Port>[] };
+> & {
+  inputs: ReactElement<Port & HTMLAttributes<HTMLDivElement>>[];
+  outputs: ReactElement<Port & HTMLAttributes<HTMLDivElement>>[];
+};
 
 export type Link = {
   input: string;

--- a/@types/DiagramSchema.ts
+++ b/@types/DiagramSchema.ts
@@ -1,4 +1,4 @@
-import { ElementType, ReactNode } from 'react';
+import { ElementType, ReactElement, ReactNode } from 'react';
 
 export type PortAlignment = 'right' | 'left' | 'top' | 'bottom';
 
@@ -18,12 +18,15 @@ export type Node<P> = {
   inputs?: Port[];
   outputs?: Port[];
   type?: 'default';
-  render?: (
-    props: Omit<Node<P>, 'coordinates'>
-  ) => ElementType | ReactNode;
+  render?: (props: NodeRenderProps<P>) => ElementType | ReactNode;
   className?: string;
   data?: P;
 };
+
+export type NodeRenderProps<P> = Omit<
+  Node<P>,
+  'coordinates' | 'disableDrag' | 'inputs' | 'outputs'
+> & { inputs: ReactElement<Port>[]; outputs: ReactElement<Port>[] };
 
 export type Link = {
   input: string;

--- a/index-tests.tsx
+++ b/index-tests.tsx
@@ -55,8 +55,8 @@ export const UncontrolledDiagram2 = () => {
           style={{ padding: '15px', background: 'purple' }}
         >
           {content}
-          {inputs?.map((input) => (<div>{input.props.id}</div>))}
-          {outputs?.map((output) => (<div>{output.props.id}</div>))}
+          {inputs.map((input) => (<div>{input.props.id}</div>))}
+          {outputs.map((output) => (<div>{output.props.id}</div>))}
         </div>
       ),
       data: {

--- a/index-tests.tsx
+++ b/index-tests.tsx
@@ -48,19 +48,22 @@ export const UncontrolledDiagram2 = () => {
         schema.nodes[schema.nodes.length - 1].coordinates[0] + 10,
         schema.nodes[schema.nodes.length - 1].coordinates[1] + 20,
       ],
-      render: ({ content, data }) => (
+      render: ({ content, data, inputs, outputs }) => (
         <div
           onDoubleClick={data?.onDoubleClick}
           role='button'
           style={{ padding: '15px', background: 'purple' }}
         >
           {content}
+          {inputs?.map((input) => (<div>{input.props.id}</div>))}
+          {outputs?.map((output) => (<div>{output.props.id}</div>))}
         </div>
       ),
       data: {
         onDoubleClick: () => alert(`Schema length is: ${schema.nodes.length}`),
       },
       inputs: [{ id: `port-${schema.nodes.length + 1}` }],
+      outputs: [{ id: `port-${schema.nodes.length + 1}` }],
     });
 
   const removeLast = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fixed argument type of render props in Node

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
yarn test-types
```

## Screenshots (if appropriate):

```
❯ yarn test-types
yarn run v1.22.5
$ npx tsc -p . --noEmit
✨  Done in 3.28s.
```