### PR TITLE
fix: link direction flow

### DIFF
--- a/src/Diagram/Port/Port.js
+++ b/src/Diagram/Port/Port.js
@@ -29,7 +29,7 @@ const Port = (props) => {
   onDragEnd((event) => {
     const targetPort = event.target.getAttribute('data-port-id');
     if (targetPort && event.target !== ref.current && canLink(id, targetPort, type) && onSegmentConnect) {
-      const args = type === 'input' ? [id, targetPort, type] : [targetPort, id, type];
+      const args = type === 'output' ? [id, targetPort, type] : [targetPort, id, type];
 
       onSegmentConnect(...args);
       return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixing direction flow of links

## Related Issue
#108 

## Motivation and Context
Direction flow of links are inverted, no matter which port originated the drag.

## How Has This Been Tested?

- Open https://antonioru.github.io/beautiful-react-diagrams/#/Ports
- Hover the mouse over the link. Flow is correct.
- Double click on link to remove it
- Drag port 1 (top right of start node) to port 4 (bottom left on Middle node)
- Hover the mouse over the new link. Flow is inverted.

## Screenshots (if appropriate):
